### PR TITLE
Fix bug in expression dimension validation when operands contain a dimension and not units

### DIFF
--- a/djangophysics/calculations/tests.py
+++ b/djangophysics/calculations/tests.py
@@ -371,6 +371,73 @@ class ExpressionAPITest(TestCase):
                                  {'code': '[time]', 'multiplicity': 1.0}],
                                 key=lambda x: x['code']))
 
+    def test_formula_dimension_validation_request(self):
+        """
+        Test formula syntax validation
+        """
+        client = APIClient()
+        response = client.post(
+            '/units/SI/formulas/validate/',
+            data=json.dumps({
+                'expression': '(3*{a}*15*{b})*6*{c}',
+                'operands': [
+                    {
+                        'name': 'a',
+                        'value': 0.1,
+                        'unit': '[length]/[time]'
+                    },
+                    {
+                        'name': 'b',
+                        'value': 15,
+                        'unit': 'g/km*hour'
+                    },
+                    {
+                        'name': 'c',
+                        'value': 12,
+                        'unit': 's*[temperature]'
+                    }
+                ]
+            }),
+            content_type="application/json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(sorted(json.loads(response.content), key=lambda x: x['code']),
+                         sorted([{'code': '[mass]', 'multiplicity': 1.0},
+                                 {'code': '[temperature]', 'multiplicity': 1.0},
+                                 {'code': '[time]', 'multiplicity': 1.0}],
+                                key=lambda x: x['code']))
+
+    def test_formula_dimension_validation_invalid_syntax_request(self):
+        """
+        Test formula syntax validation
+        """
+        client = APIClient()
+        response = client.post(
+            '/units/SI/formulas/validate/',
+            data=json.dumps({
+                'expression': '(3*{a}*15*{b})*6*{c}',
+                'operands': [
+                    {
+                        'name': 'a',
+                        'value': 0.1,
+                        'unit': '[length]/[time]'
+                    },
+                    {
+                        'name': 'b',
+                        'value': 15,
+                        'unit': 'g/km*hour'
+                    },
+                    {
+                        'name': 'c',
+                        'value': 12,
+                        'unit': 's*[temperature]]'
+                    }
+                ]
+            }),
+            content_type="application/json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_406_NOT_ACCEPTABLE)
+
     def test_formula_validation_out_units_request(self):
         """
         Test formula output dimensions validation

--- a/djangophysics/calculations/viewsets.py
+++ b/djangophysics/calculations/viewsets.py
@@ -3,6 +3,7 @@ Calculations module APIs viewsets
 """
 
 import json
+from tokenize import TokenError
 
 from drf_yasg.utils import swagger_auto_schema
 from pint import UndefinedUnitError, DimensionalityError
@@ -48,14 +49,16 @@ class ValidateViewSet(APIView):
         try:
             if exp.is_valid(unit_system=us, dimensions_only=True):
                 expression = exp.create(exp.validated_data)
-                return Response(DimensionalitySerializer(
-                    expression.dimensionality(unit_system=us), many=True).data,
+                return Response(
+                    DimensionalitySerializer(
+                        expression.dimensionality(unit_system=us), many=True
+                    ).data,
                     content_type="application/json")
             else:
                 return Response(json.dumps(exp.errors),
                                 status=status.HTTP_406_NOT_ACCEPTABLE,
                                 content_type="application/json")
-        except (UndefinedUnitError, DimensionalityError) as e:
+        except (UndefinedUnitError, DimensionalityError, TokenError) as e:
             return Response(str(e),
                             status=status.HTTP_400_BAD_REQUEST,
                             content_type="application/json")

--- a/djangophysics/version.py
+++ b/djangophysics/version.py
@@ -1,1 +1,1 @@
-djangophysics_version = [1, 4, 1, ""]
+djangophysics_version = [1, 5, 0, ""]


### PR DESCRIPTION
The bug resulted in wrong units error when dimensions where used in operands