### PR TITLE
add test for bad currency in conversion

### DIFF
--- a/djangophysics/rates/models.py
+++ b/djangophysics/rates/models.py
@@ -508,7 +508,9 @@ class RateConverter(BaseConverter):
         """
         result = ConverterResult(id=self.id, target=self.base_currency)
         for amount in self.data:
-            rate = self.cached_currencies[amount.date_obj][amount.currency]
+            rate = self.cached_currencies.get(
+                amount.date_obj, {}
+            ).get(amount.currency)
             if rate:
                 value = float(amount.amount) / rate
                 result.increment_sum(value)

--- a/djangophysics/rates/tests.py
+++ b/djangophysics/rates/tests.py
@@ -1016,6 +1016,34 @@ class RateConverterAPITest(TestCase):
         self.assertIn('sum', response.json())
         self.assertEqual(len(response.json().get('detail')), len(self.amounts))
 
+    def test_convert_error_request(self):
+        """
+        Test conversion request
+        """
+        payload = {
+          "data": [
+            {
+              "currency": "AMD",
+              "amount": 22,
+              "date_obj": "2021-08-03"
+            }
+          ],
+          "target": "EUR"
+        }
+        Rate.objects.fetch_rates(
+            base_currency=self.base_currency,
+            currency=self.currency)
+        Rate.objects.fetch_rates(base_currency=self.currency, currency='AUD')
+        amounts = RateAmountSerializer(self.amounts, many=True)
+        client = APIClient()
+        response = client.post(
+            '/rates/convert/',
+            data=payload,
+            format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn('errors', response.json())
+        self.assertEqual(response.json().get('errors')[0]['unit'], 'AMD')
+
     def test_convert_batch_request(self):
         """
         Test batch conversion


### PR DESCRIPTION
{
  "data": [
    {
      "currency": "AMD",
      "amount": 22,
      "date_obj": "2021-08-03"
    }
  ],
  "target": "EUR"
}
crashes the currency conversion API