### PR TITLE
Add expression ID in calculations.

### DIFF
--- a/djangophysics/calculations/tests.py
+++ b/djangophysics/calculations/tests.py
@@ -703,7 +703,7 @@ class ExpressionCalculatorTest(TestCase):
         calculator = ExpressionCalculator(unit_system='SI')
         errors = calculator.add_data(self.trash_expressions)
         self.assertEqual(len(errors), 3)
-        self.assertEqual([list(c.keys())[0] for c in errors],
+        self.assertEqual([c.errors[0].get('source') for c in errors],
                          ['expression', 'expression', 'out_units'])
 
     def test_add_empty_data(self):

--- a/djangophysics/calculations/viewsets.py
+++ b/djangophysics/calculations/viewsets.py
@@ -105,12 +105,15 @@ class CalculationView(APIView):
                             status=status.HTTP_400_BAD_REQUEST)
         if cp.data:
             errors = calculator.add_data(data=cp.data)
-            if errors:
-                return Response(errors, status=HTTP_400_BAD_REQUEST)
+            # Who cares if there are errors, they'll be notified on conversion
+            # if errors:
+            #     return Response(errors, status=HTTP_400_BAD_REQUEST)
         if cp.eob or not cp.batch_id:
             result = calculator.convert()
+            result.errors.extend(errors)
             serializer = CalculationResultSerializer(result)
-            return Response(serializer.data, content_type="application/json")
+            data = serializer.data
+            return Response(data, content_type="application/json")
         else:
             return Response({'id': calculator.id, 'status': calculator.status},
                             content_type="application/json")


### PR DESCRIPTION
ID can be defined by the consumer, or is generated automatically.
Also changed calculation validation: errors in expression are reported in 'errors' key, and expressions that are valid are now evaluated instead of returning a general 400 error.